### PR TITLE
Handle inflate returning Z_OK at end of stream

### DIFF
--- a/src/png.inl
+++ b/src/png.inl
@@ -851,7 +851,7 @@ PNG_STATIC int DecodePNG(PNGIMAGE *pPage, void *pUser, int iOptions)
                             tmp = NULL;
                         }
                     }
-                    if (err == Z_STREAM_END && d_stream.avail_out == 0) {
+                    if (err == Z_STREAM_END) {
                         // successful decode, stop here
                         y = pPage->iHeight;
                         bDone = TRUE;


### PR DESCRIPTION
The inflate function may return `Z_OK` rather than `Z_STREAM_END` when the last bytes of the stream are inflated. In this case inflate returns `Z_STREAM_END` on the next call. However in this situation we will already have reset `avail_out` for the next line and the `d_stream.avail_out == 0` condition will be false.

The zlib documentation is not very clear about this, but I have verified that it still behaves this way in version 1.3.1.