### PR TITLE
Fix uint instead of uInt in inflateSetDictionary

### DIFF
--- a/src/inflate.c
+++ b/src/inflate.c
@@ -1480,7 +1480,7 @@ int ZEXPORT inflateGetDictionary(z_streamp strm, Bytef *dictionary, uInt *dictLe
     return Z_OK;
 }
 
-int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef *dictionary, uint dictLength)
+int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef *dictionary, uInt dictLength)
 {
     struct inflate_state FAR *state;
     unsigned long dictid;


### PR DESCRIPTION
Consistent with the rest of the file, also fixes a build error on one compiler.