### PR TITLE
Changed "local" in .c/,h files to PNG_STATIC to reflect the change in pngdec.h 

### DIFF
--- a/src/PNGdec.h
+++ b/src/PNGdec.h
@@ -52,11 +52,7 @@
 // Defaults to 320 32-bit pixels max width
 // but can be overidden with a macro defined at compile time
 #ifndef PNG_MAX_BUFFERED_PIXELS
-#if defined( __LINUX__ ) || defined( __MACH__ )
-#define PNG_MAX_BUFFERED_PIXELS 16386
-#else
 #define PNG_MAX_BUFFERED_PIXELS ((320*4 + 1)*2)
-#endif
 #endif
 
 #ifndef __PNGENC__
@@ -218,12 +214,10 @@ void PNG_setBuffer(PNGIMAGE *pPNG, uint8_t *pBuffer);
 #endif // __cplusplus
 
 // Due to unaligned memory causing an exception, we have to do these macros the slow way
-#ifndef MOTOLONG
 #define INTELSHORT(p) ((*p) + (*(p+1)<<8))
 #define INTELLONG(p) ((*p) + (*(p+1)<<8) + (*(p+2)<<16) + (*(p+3)<<24))
 #define MOTOSHORT(p) (((*(p))<<8) + (*(p+1)))
 #define MOTOLONG(p) (((*p)<<24) + ((*(p+1))<<16) + ((*(p+2))<<8) + (*(p+3)))
-#endif
 
 // Must be a 32-bit target processor
 #define REGISTER_WIDTH 32

--- a/src/adler32.c
+++ b/src/adler32.c
@@ -10,7 +10,7 @@
 #ifndef __ADLER32_C__
 #define __ADLER32_C__
 
-local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
+PNG_STATIC uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 
 #define BASE 65521U     /* largest prime smaller than 65536 */
 #define NMAX 5552
@@ -137,7 +137,7 @@ uLong ZEXPORT adler32(uLong adler, const Bytef *buf, uInt len)
 }
 
 /* ========================================================================= */
-local uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2)
+PNG_STATIC uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2)
 {
     unsigned long sum1;
     unsigned long sum2;

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -35,9 +35,9 @@
 #  define BYFOUR
 #endif
 #ifdef BYFOUR
-   local unsigned long crc32_little OF((unsigned long,
+   PNG_STATIC unsigned long crc32_little OF((unsigned long,
                         const unsigned char FAR *, z_size_t));
-   local unsigned long crc32_big OF((unsigned long,
+   PNG_STATIC unsigned long crc32_big OF((unsigned long,
                         const unsigned char FAR *, z_size_t));
 #  define TBLS 8
 #else
@@ -45,19 +45,19 @@
 #endif /* BYFOUR */
 
 /* Local functions for crc concatenation */
-local unsigned long gf2_matrix_times OF((unsigned long *mat,
+PNG_STATIC unsigned long gf2_matrix_times OF((unsigned long *mat,
                                          unsigned long vec));
-local void gf2_matrix_square OF((unsigned long *square, unsigned long *mat));
-local uLong crc32_combine_ OF((uLong crc1, uLong crc2, z_off64_t len2));
+PNG_STATIC void gf2_matrix_square OF((unsigned long *square, unsigned long *mat));
+PNG_STATIC uLong crc32_combine_ OF((uLong crc1, uLong crc2, z_off64_t len2));
 
 
 #ifdef DYNAMIC_CRC_TABLE
 
-local volatile int crc_table_empty = 1;
-local z_crc_t FAR crc_table[TBLS][256];
-local void make_crc_table OF((void));
+PNG_STATIC volatile int crc_table_empty = 1;
+PNG_STATIC z_crc_t FAR crc_table[TBLS][256];
+PNG_STATIC void make_crc_table OF((void));
 #ifdef MAKECRCH
-   local void write_table OF((FILE *, const z_crc_t FAR *));
+   PNG_STATIC void write_table OF((FILE *, const z_crc_t FAR *));
 #endif /* MAKECRCH */
 /*
   Generate tables for a byte-wise 32-bit CRC calculation on the polynomial:

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -257,7 +257,7 @@ unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char FAR *buf, uIn
 #define DOLIT32 DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4
 
 /* ========================================================================= */
-local unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf, z_size_t len)
+PNG_STATIC unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf, z_size_t len)
 {
     register z_crc_t c;
     register const z_crc_t FAR *buf4;
@@ -294,7 +294,7 @@ local unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
-local unsigned long crc32_big(unsigned long crc, const unsigned char FAR *buf, z_size_t len)
+PNG_STATIC unsigned long crc32_big(unsigned long crc, const unsigned char FAR *buf, z_size_t len)
 {
     register z_crc_t c;
     register const z_crc_t FAR *buf4;
@@ -329,7 +329,7 @@ local unsigned long crc32_big(unsigned long crc, const unsigned char FAR *buf, z
 #define GF2_DIM 32      /* dimension of GF(2) vectors (length of CRC) */
 
 /* ========================================================================= */
-local unsigned long gf2_matrix_times(unsigned long *mat, unsigned long vec)
+PNG_STATIC unsigned long gf2_matrix_times(unsigned long *mat, unsigned long vec)
 {
     unsigned long sum;
 
@@ -344,7 +344,7 @@ local unsigned long gf2_matrix_times(unsigned long *mat, unsigned long vec)
 }
 
 /* ========================================================================= */
-local void gf2_matrix_square(unsigned long *square, unsigned long *mat)
+PNG_STATIC void gf2_matrix_square(unsigned long *square, unsigned long *mat)
 {
     int n;
 
@@ -353,7 +353,7 @@ local void gf2_matrix_square(unsigned long *square, unsigned long *mat)
 }
 
 /* ========================================================================= */
-local uLong crc32_combine_(uLong crc1, uLong crc2, z_off64_t len2)
+PNG_STATIC uLong crc32_combine_(uLong crc1, uLong crc2, z_off64_t len2)
 {
     int n;
     unsigned long row;

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -2,7 +2,7 @@
  * Generated automatically by crc32.c
  */
 
-local const z_crc_t FAR crc_table[TBLS][256] =
+PNG_STATIC const z_crc_t FAR crc_table[TBLS][256] =
 {
   {
     0x00000000UL, 0x77073096UL, 0xee0e612cUL, 0x990951baUL, 0x076dc419UL,

--- a/src/infback.c
+++ b/src/infback.c
@@ -16,7 +16,7 @@
 #include "inffast.h"
 
 /* function prototypes */
-local void fixedtables (struct inflate_state FAR *state);
+PNG_STATIC void fixedtables (struct inflate_state FAR *state);
 
 /*
    strm provides memory allocation functions in zalloc and zfree, or
@@ -74,7 +74,7 @@ int ZEXPORT inflateBackInit_(z_streamp strm, int windowBits, unsigned char FAR *
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(struct inflate_state FAR *state)
+PNG_STATIC void fixedtables(struct inflate_state FAR *state)
 {
 #ifdef BUILDFIXED
     static int virgin = 1;

--- a/src/inffast.c
+++ b/src/inffast.c
@@ -13,7 +13,7 @@
 #else
 
 #if ((INTPTR_MAX == INT64_MAX) || defined(HAL_ESP32_HAL_H_) || defined(TEENSYDUINO) || defined(ARM_MATH_CM4) || defined(ARM_MATH_CM7)) && !defined(ARDUINO_ARCH_RP2040)
-//#define ALLOWS_UNALIGNED
+#define ALLOWS_UNALIGNED
 #endif
 /*
    Decode literal, length, and distance codes and write out the resulting

--- a/src/inflate.c
+++ b/src/inflate.c
@@ -96,17 +96,17 @@
 #endif
 
 /* function prototypes */
-local int inflateStateCheck OF((z_streamp strm));
-local void fixedtables(struct inflate_state FAR *state);
-local int updatewindow OF((z_streamp strm, const unsigned char FAR *end,
+PNG_STATIC int inflateStateCheck OF((z_streamp strm));
+PNG_STATIC void fixedtables(struct inflate_state FAR *state);
+PNG_STATIC int updatewindow OF((z_streamp strm, const unsigned char FAR *end,
                            unsigned copy));
 #ifdef BUILDFIXED
 void makefixed OF((void));
 #endif
-local unsigned syncsearch OF((unsigned FAR *have, const unsigned char FAR *buf,
+PNG_STATIC unsigned syncsearch OF((unsigned FAR *have, const unsigned char FAR *buf,
                               unsigned len));
 
-local int inflateStateCheck(z_streamp strm)
+PNG_STATIC int inflateStateCheck(z_streamp strm)
 {
     struct inflate_state FAR *state;
     if (strm == Z_NULL ||
@@ -278,7 +278,7 @@ int ZEXPORT inflatePrime(z_streamp strm, int bits, int value)
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(struct inflate_state FAR *state)
+PNG_STATIC void fixedtables(struct inflate_state FAR *state)
 {
 #ifdef BUILDFIXED
     static int virgin = 1;
@@ -407,7 +407,7 @@ void makefixed()
    output will fall in the output data, making match copies simpler and faster.
    The advantage may be dependent on the size of the processor's data caches.
  */
-local int updatewindow(z_streamp strm, const Bytef *end, unsigned copy)
+PNG_STATIC int updatewindow(z_streamp strm, const Bytef *end, unsigned copy)
 {
     struct inflate_state FAR *state;
     unsigned dist;
@@ -1543,7 +1543,7 @@ int ZEXPORT inflateGetHeader(z_streamp strm, gz_headerp head)
    called again with more data and the *have state.  *have is initialized to
    zero for the first call.
  */
-local unsigned syncsearch(unsigned FAR *have, const unsigned char FAR *buf, unsigned len)
+PNG_STATIC unsigned syncsearch(unsigned FAR *have, const unsigned char FAR *buf, unsigned len)
 {
     unsigned got;
     unsigned next;

--- a/src/zutil.c
+++ b/src/zutil.c
@@ -197,14 +197,14 @@ void ZLIB_INTERNAL zmemzero(dest, len)
 #define MAX_PTR 10
 /* 10*64K = 640K */
 
-local int next_ptr = 0;
+PNG_STATIC int next_ptr = 0;
 
 typedef struct ptr_table_s {
     voidpf org_ptr;
     voidpf new_ptr;
 } ptr_table;
 
-local ptr_table table[MAX_PTR];
+PNG_STATIC ptr_table table[MAX_PTR];
 /* This table is used to remember the original form of pointers
  * to large buffers (64K). Such pointers are normalized with a zero offset.
  * Since MSDOS is not a preemptive multitasking OS, this table is not

--- a/src/zutil.h
+++ b/src/zutil.h
@@ -34,8 +34,8 @@
    typedef long ptrdiff_t;  /* guess -- will be caught if guess is wrong */
 #endif
 
-#ifndef local
-#  define local static
+#ifndef PNG_STATIC
+#  define PNG_STATIC static
 #endif
 /* since "static" is used to mean two completely different things in C, we
    define "local" for the non-static meaning of "static", for readability


### PR DESCRIPTION
While using the PNGDec library in a Teensy 4.1 application ran into an issue conflict with using local = static in the lib.


Noticed in version 1.1.6 you changed it to `#define PNG_STATIC static` but this was not carried through into other .c/h files which was causing the conflicts.  I went ahead and changed the `local` function  to `PNG_STATIC` function name and then it compiled and worked without issue.

PS>  also bumped the library version.

Hope this is right.